### PR TITLE
Fixes for PowerShell usage and SSH error in WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are using Windows Insider builds greater than 21286 you should use the [`
 1. Run `Install-Module -Scope CurrentUser Wsl` to install the required PowerShell module
 1. Download the `install.ps1` script
 1. Open a PowerShell or CMD window: press `Win + x` then choose either "Command Prompt" or "Windows PowerShell" depending on which your system presents in the menu
-1. Run the following command in the PowerShell or CMD window to set up your default distro
+1. Run the following command in the PowerShell or CMD window to set up your default distro (make sure to replace `powershell.exe` with `pwsh.exe` if you're using PowerShell Core):
     ```powershell
     powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -File \path\to\install.ps1
     ```

--- a/install.ps1
+++ b/install.ps1
@@ -403,6 +403,7 @@ Invoke-WslCommand -User 'root' -Command "usermod -a -G sudo $User 2>/dev/null"
 Invoke-WslCommand -User 'root' -Command "usermod -a -G wheel $User 2>/dev/null"
 
 Write-Output "--- Installing files in $($Distribution.Name)"
+Invoke-WslCommand -Command 'mkdir -p $HOME/.ssh'
 Add-WslFiles -Distribution $Distribution -Files $files @params
 
 Write-Output "--- Setting systemd to automatically start in $($Distribution.Name)"

--- a/install.ps1
+++ b/install.ps1
@@ -84,6 +84,8 @@ $agentfiles = @{
 
 $npiperelayUrl = 'https://github.com/NZSmartie/npiperelay/releases/download/v0.1/npiperelay.exe'
 
+$powershellProcess = (Get-Process -Id $PID).ProcessName + '.exe'
+
 if ($IsWindows -or $PSVersionTable.PSVersion.Major -lt 6) {
     $wslPath = "$env:windir\system32\wsl.exe"
     if (-not [System.Environment]::Is64BitProcess) {
@@ -768,7 +770,7 @@ if ($response.StatusCode -eq 200) {
         $CmdArgs += @('-NoKernel')
     }
     try {
-        Start-Process -Verb RunAs -Wait -FilePath powershell.exe -Args '-NonInteractive', '-ExecutionPolicy', 'ByPass', '-Command', "$adminScript $CmdArgs"
+        Start-Process -Verb RunAs -Wait -FilePath $powershellProcess -Args '-NonInteractive', '-ExecutionPolicy', 'ByPass', '-Command', "$adminScript $CmdArgs"
     } finally {
         Remove-Item $adminScript
     }
@@ -778,5 +780,5 @@ if ($response.StatusCode -eq 200) {
 
 Write-Output "`nDone."
 Write-Output "If you want to go back to the Microsoft kernel open a PowerShell or CMD window and run:"
-Write-Output "`n`tpowershell.exe -NonInteractive -NoProfile -Command 'Start-Process' -Verb RunAs -FilePath powershell.exe -ArgumentList { Unregister-ScheduledJob -Name UpdateWSL2CustomKernel }"
+Write-Output "`n`t$powershellProcess -NonInteractive -NoProfile -Command 'Start-Process' -Verb RunAs -FilePath $powershellProcess -ArgumentList { Unregister-ScheduledJob -Name UpdateWSL2CustomKernel }"
 Write-Output "`n"


### PR DESCRIPTION
Right now the script uses `powershell.exe` even if user is using `pwsh.exe` which can lead to multiple side-effects. This PR fixes it by taking the name of the current process.
Also added a warning in the README to use the right shell.

Another fix is to make sure `.ssh` folder exists in home folder, otherwise user will see the following error:
```shellscript
2021/07/13 22:55:09 socat[406] E bind(5, {AF=1 "/home/username/.ssh/agent.sock"}, 34): No such file or directory
```